### PR TITLE
feat: 비동기적으로 이미지 thumbnail 적용 (#10)

### DIFF
--- a/SpectaClone-iOS/SpectaClone-iOS.xcodeproj/project.pbxproj
+++ b/SpectaClone-iOS/SpectaClone-iOS.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		F81CC2F72837EEC900C2BA0E /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81CC2F62837EEC900C2BA0E /* NetworkError.swift */; };
 		F83D8671282CCDA400EC5618 /* Const.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83D8670282CCDA400EC5618 /* Const.swift */; };
 		F83D8673282CEAAE00EC5618 /* ImageDownloadError.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83D8672282CEAAE00EC5618 /* ImageDownloadError.swift */; };
+		F885D5CA2862B48800663746 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F885D5C92862B48800663746 /* UIImage+.swift */; };
 		F889574F282BF117003651AA /* Then in Frameworks */ = {isa = PBXBuildFile; productRef = F889574E282BF117003651AA /* Then */; };
 		F8895752282BF7E8003651AA /* UIView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8895751282BF7E8003651AA /* UIView+.swift */; };
 		F8895755282BF91A003651AA /* MovieCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8895754282BF91A003651AA /* MovieCollectionViewCell.swift */; };
@@ -44,6 +45,7 @@
 		F81CC2F62837EEC900C2BA0E /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		F83D8670282CCDA400EC5618 /* Const.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Const.swift; sourceTree = "<group>"; };
 		F83D8672282CEAAE00EC5618 /* ImageDownloadError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageDownloadError.swift; sourceTree = "<group>"; };
+		F885D5C92862B48800663746 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		F8895751282BF7E8003651AA /* UIView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+.swift"; sourceTree = "<group>"; };
 		F8895754282BF91A003651AA /* MovieCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieCollectionViewCell.swift; sourceTree = "<group>"; };
 		F8895757282C3925003651AA /* PopularMovie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularMovie.swift; sourceTree = "<group>"; };
@@ -133,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				F8895751282BF7E8003651AA /* UIView+.swift */,
+				F885D5C92862B48800663746 /* UIImage+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -296,6 +299,7 @@
 				F81CC2E828378F4E00C2BA0E /* HTTPMethod.swift in Sources */,
 				F81CC2F5283798D900C2BA0E /* TargetType.swift in Sources */,
 				F81CC2E228377FE400C2BA0E /* NetworkService.swift in Sources */,
+				F885D5CA2862B48800663746 /* UIImage+.swift in Sources */,
 				F81CC2F2283797C600C2BA0E /* GenericResponse.swift in Sources */,
 				F89BA77C282B5D3B00B715D2 /* SceneDelegate.swift in Sources */,
 				F83D8673282CEAAE00EC5618 /* ImageDownloadError.swift in Sources */,

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/Cells/MovieCollectionViewCell.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/Cells/MovieCollectionViewCell.swift
@@ -56,8 +56,8 @@ extension MovieCollectionViewCell {
                 print("image download error - unsupportImage")
             } catch ImageDownloadError.invalidServerResponse {
                 print("image download error - invalidServerResponse")
-            } catch ImageDownloadError.invalidURLString {
-                print("image download error - invalidURLString")
+            } catch ImageDownloadError.invalidURLString(let urlPath) {
+                print("image download error - invalidURLString: \(urlPath)")
             }
         }
     }

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/Extension/UIImage+.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/Extension/UIImage+.swift
@@ -1,0 +1,17 @@
+//
+//  UIImage+.swift
+//  SpectaClone-iOS
+//
+//  Created by kimhyungyu on 2022/06/22.
+//
+
+import UIKit
+
+extension UIImage {
+    var thumbnail: UIImage? {
+        get async {
+            let size = CGSize(width: 100, height: 140)
+            return await self.byPreparingThumbnail(ofSize: size)
+        }
+    }
+}

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/Module/ImageDownloader.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/Module/ImageDownloader.swift
@@ -26,7 +26,9 @@ actor ImageDownloader {
         
         cache[url] = cache[url, default: image]
         
-        return cache[url]!
+        guard let thumbnailImage = await cache[url]?.thumbnail else { throw ImageDownloadError.unsupportImage }
+        
+        return thumbnailImage
     }
 
     private func downloadImage(from url: URL) async throws -> UIImage {

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/Module/ImageDownloader.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/Module/ImageDownloader.swift
@@ -15,7 +15,7 @@ actor ImageDownloader {
     
     func image(from urlPath: String) async throws -> UIImage? {
         guard let url = URL(string: Const.Path.imageURLPath + urlPath) else {
-            throw ImageDownloadError.invalidURLString
+            throw ImageDownloadError.invalidURLString(Const.Path.imageURLPath + urlPath)
         }
         
         if let cached = cache[url] {

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/Module/NetworkProvider.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/Module/NetworkProvider.swift
@@ -34,7 +34,7 @@ struct NetworkProvider<Target: TargetType> {
             }
         }
         guard let url = url else {
-            throw DataDownloadError.invalidURLString
+            throw DataDownloadError.emptyURL
         }
         
         // method

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/NetworkModels/Error/DataDownloadError.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/NetworkModels/Error/DataDownloadError.swift
@@ -13,8 +13,8 @@ enum DataDownloadError: Error {
     /// 유효하지 않은 URLComponents 생성 오류.
     case invalidURLComponents
     
-    /// 유효하지 않은 URL  형식 오류.
-    case invalidURLString
+    /// URL 가 없음.
+    case emptyURL
     
     /// 응답으로 HTTPURLResponse 가 오지 않는 유효하지 않은 통신 오류.
     case invalidServerResponse

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/NetworkModels/Error/ImageDownloadError.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/NetworkModels/Error/ImageDownloadError.swift
@@ -11,7 +11,7 @@ import Foundation
 enum ImageDownloadError: Error {
     
     /// 유효하지 않은 URL 형식 오류.
-    case invalidURLString
+    case invalidURLString(_ urlPath: String)
     
     /// 유효하지 않은 Server Response 오류.
     case invalidServerResponse

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/NetworkModels/Error/NetworkError.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/NetworkModels/Error/NetworkError.swift
@@ -11,7 +11,7 @@ import Foundation
 enum NetworkError: Error {
     
     /// 디코딩 에러.
-    /// - Parameter toType : Deciadable 을 채택하는 디코딩 가능한 자료형. existential metatype 이다.
+    /// - Parameter toType : Decodable 을 채택하는 디코딩 가능한 자료형. existential metatype 이다.
     case decodeError(toType: Decodable.Type)
     
     /// 서버 요청 에러.

--- a/SpectaClone-iOS/SpectaClone-iOS/Source/ViewControllers/ViewController.swift
+++ b/SpectaClone-iOS/SpectaClone-iOS/Source/ViewControllers/ViewController.swift
@@ -46,7 +46,7 @@ class ViewController: UIViewController {
                 await MainActor.run {
                     movieCollectionView.reloadData()
                 }
-            } catch DataDownloadError.invalidURLString {
+            } catch DataDownloadError.emptyURL {
                 print("movie error - invalidURLString")
             } catch DataDownloadError.invalidServerResponse {
                 print("movie error - invalidServerResponse")


### PR DESCRIPTION
_**🧌SpectaClone Coding**_

## 📢 Contents
- `byPreparingThumbnail(ofSize:)` async 메서드를 사용하여 백그라운드 스레드에서 비동기적으로 이미지를 지정한 사이즈로 디코딩할 수 있도록 하였다.
- 큰 이미지의 경우 디코딩을 필요한만큼 함으로써 불필요한 메모리를 절약할 수 있다.

> close #10
